### PR TITLE
Add `require` option to call browserify.require()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ BrowserifyFilter.prototype.transform = function (srcDir, destDir) {
   var options = this.options;
   var browserify_options = options.browserify || {};
   var bundle_options = options.bundle || {};
+  var require_options = options.require || {};
 
   mkdirp.sync(path.join(destDir, path.dirname(options.outputFile)))
 
@@ -29,6 +30,9 @@ BrowserifyFilter.prototype.transform = function (srcDir, destDir) {
 
   for(var i=0; i < options.entries.length; i++){
     b.add(options.entries[i]);
+  }
+  for(var i=0; i < require_options.length; i++){
+    b.require.apply(b, require_options[i]);
   }
 
   return new RSVP.Promise(function(resolve, reject) {


### PR DESCRIPTION
Usage example:

``` javascript
var browserifyFilter = require('broccoli-browserify');
return browserifyFilter(tree, {
  entries: [
    require.resolve(require('traceur').RUNTIME_PATH),
    './main-module'
  ],
  bundle: { debug: true },
  require: [
    ['./main-module', { expose: 'main-module' }],
    ['jquery-browserify', { expose: 'jquery' }]
  ],
  outputFile: 'main-module.js'
});
```
