### PR TITLE
Use writer instead of transform

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,46 +1,54 @@
-var Transform = require('broccoli-transform');
+var fs = require('fs');
+var path = require('path');
 var RSVP = require('rsvp');
+var mkdirp = require('mkdirp');
 var browserify = require('browserify')
-var mkdirp = require('mkdirp')
-var fs = require('fs')
-var path = require('path')
+var Writer = require('broccoli-writer');
 
-function BrowserifyFilter(inputTree, options) {
-  if (!(this instanceof BrowserifyFilter)) {
-    return new BrowserifyFilter(inputTree, options);
+function BrowserifyWriter(inputTree, options) {
+  if (!(this instanceof BrowserifyWriter)) {
+    return new BrowserifyWriter(inputTree, options);
   }
 
+  options = options || {};
+
+  this.entries = options.entries || [];
+  this.outputFile = options.outputFile || '/browserify.js';
+  this.browserifyOptions = options.browserify || {};
+  this.bundleOptions = options.bundle || {};
   this.inputTree = inputTree;
-  this.options = options || {};
 }
 
-BrowserifyFilter.prototype = Object.create(Transform.prototype);
-BrowserifyFilter.prototype.constructor = BrowserifyFilter;
+BrowserifyWriter.prototype = Object.create(Writer.prototype);
+BrowserifyWriter.prototype.constructor = BrowserifyWriter;
 
-BrowserifyFilter.prototype.transform = function (srcDir, destDir) {
-  var options = this.options;
-  var browserify_options = options.browserify || {};
-  var bundle_options = options.bundle || {};
+BrowserifyWriter.prototype.write = function (readTree, destDir) {
+  var entries = this.entries;
+  var outputFile = this.outputFile;
+  var browserifyOptions = this.browserifyOptions;
+  var bundleOptions = this.bundleOptions;
 
-  mkdirp.sync(path.join(destDir, path.dirname(options.outputFile)))
+  return readTree(this.inputTree).then(function (srcDir) {
+    mkdirp.sync(path.join(destDir, path.dirname(outputFile)));
 
-  browserify_options.basedir = srcDir;
-  var b = browserify(browserify_options);
+    browserifyOptions.basedir = srcDir;
+    var b = browserify(browserifyOptions);
 
-  for (var i = 0; i < options.entries.length; i++) {
-    b.add(options.entries[i]);
-  }
+    for (var i = 0; i < entries.length; i++) {
+      b.add(entries[i]);
+    }
 
-  return new RSVP.Promise(function (resolve, reject) {
-    b.bundle(bundle_options, function (err, data) {
-      if (err) {
-        return reject(err);
-      }
-      fs.writeFileSync(path.join(destDir, options.outputFile), data)
-
-      resolve(destDir);
+    return new RSVP.Promise(function (resolve, reject) {
+      b.bundle(bundleOptions, function (err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          fs.writeFileSync(path.join(destDir, outputFile), data);
+          resolve(destDir);
+        }
+      });
     });
-  }.bind(this));
+  });
 };
 
-module.exports = BrowserifyFilter;
+module.exports = BrowserifyWriter;

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,11 @@ BrowserifyFilter.prototype.transform = function (srcDir, destDir) {
   browserify_options.basedir = srcDir;
   var b = browserify(browserify_options);
 
-  for(var i=0; i < options.entries.length; i++){
+  for (var i = 0; i < options.entries.length; i++) {
     b.add(options.entries[i]);
   }
 
-  return new RSVP.Promise(function(resolve, reject) {
+  return new RSVP.Promise(function (resolve, reject) {
     b.bundle(bundle_options, function (err, data) {
       if (err) {
         return reject(err);
@@ -44,5 +44,3 @@ BrowserifyFilter.prototype.transform = function (srcDir, destDir) {
 };
 
 module.exports = BrowserifyFilter;
-
-

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "broccoli-transform": "^0.1.1",
     "rsvp": "^3.0.6",
     "browserify": "^3.31.2",
-    "mkdirp": "^0.3.5",
-    "broccoli": "^0.2.1"
+    "mkdirp": "^0.3.5"
   },
   "devDependencies": {
     "jshint": "^2.4.4"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/gingerhendrix/broccoli-browserify",
   "dependencies": {
-    "broccoli-transform": "^0.1.1",
+    "broccoli-writer": "^0.1.1",
     "rsvp": "^3.0.6",
     "browserify": "^3.31.2",
-    "mkdirp": "^0.3.5"
+    "mkdirp": "^0.3.5",
   },
   "devDependencies": {
     "jshint": "^2.4.4"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli-writer": "^0.1.1",
     "rsvp": "^3.0.6",
     "browserify": "^3.31.2",
-    "mkdirp": "^0.3.5",
+    "mkdirp": "^0.3.5"
   },
   "devDependencies": {
     "jshint": "^2.4.4"


### PR DESCRIPTION
[broccoli-transform](https://github.com/joliss/broccoli-transform) is deprecated and it is recommended to use [broccoli-writer](https://github.com/broccolijs/broccoli-writer) instead. This PR makes the change and improves consistency in spacing and variable/function naming. It also removes an unnecessary (and in some cases harmful) dependency on the broccoli module.
