### PR TITLE
Exposing browserify's `external` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ tree = browserify(tree, options);
 * `require`: (default []) An array of file, option pairs
 passed to [browserify require
 method](https://github.com/substack/node-browserify#brequirefile-opts)
+* `external`: (default []) An array of file passed to [browserify external method](https://github.com/substack/node-browserify#bexternalfile)
 
 ## Changelog
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ function BrowserifyWriter(inputTree, options) {
   this.browserifyOptions = options.browserify || {};
   this.bundleOptions = options.bundle || {};
   this.requireOptions = options.require || {};
+  this.external = options.external || [];
   this.inputTree = inputTree;
 }
 
@@ -29,6 +30,7 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
   var browserifyOptions = this.browserifyOptions;
   var bundleOptions = this.bundleOptions;
   var requireOptions = this.requireOptions;
+  var external = this.external;
 
   return readTree(this.inputTree).then(function (srcDir) {
     mkdirp.sync(path.join(destDir, path.dirname(outputFile)));
@@ -42,6 +44,7 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
     for(var i = 0; i < requireOptions.length; i++){
       b.require.apply(b, requireOptions[i]);
     }
+    b.external(external);
 
     return new RSVP.Promise(function (resolve, reject) {
       b.bundle(bundleOptions, function (err, data) {


### PR DESCRIPTION
This exposes an option to call browserify's `external` method. 
