### PR TITLE
Add `transform` option to call browserify.transform()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ tree = browserify(tree, options);
 * `outputFile`: (default `"./browserify.js"`) Output file
 * `browserify` : (default `{}`) Options passed to the [browserify constructor](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts)
 * `bundle`:  (default `{}`) Options passed to [browserify bundle method](https://github.com/substack/node-browserify#bbundleopts-cb)
-* `require`: (default []) An array of file, option pairs
-passed to [browserify require
-method](https://github.com/substack/node-browserify#brequirefile-opts)
+* `require`: (default []) An array of file, option pairs passed to [browserify require method](https://github.com/substack/node-browserify#brequirefile-opts)
+* `transform`: (default []) An array of option, transform pairs passed to [browserify transform method](https://github.com/substack/node-browserify#btransformopts-tr)
 
 ## Changelog
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ function BrowserifyWriter(inputTree, options) {
   this.browserifyOptions = options.browserify || {};
   this.bundleOptions = options.bundle || {};
   this.requireOptions = options.require || {};
+  this.transformOptions = options.transform || [];
   this.inputTree = inputTree;
 }
 
@@ -29,6 +30,7 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
   var browserifyOptions = this.browserifyOptions;
   var bundleOptions = this.bundleOptions;
   var requireOptions = this.requireOptions;
+  var transformOptions = this.transformOptions;
 
   return readTree(this.inputTree).then(function (srcDir) {
     mkdirp.sync(path.join(destDir, path.dirname(outputFile)));
@@ -36,11 +38,17 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
     browserifyOptions.basedir = srcDir;
     var b = browserify(browserifyOptions);
 
-    for (var i = 0; i < entries.length; i++) {
+    var i;
+    for (i = 0; i < entries.length; i++) {
       b.add(entries[i]);
     }
-    for(var i = 0; i < requireOptions.length; i++){
+
+    for(i = 0; i < requireOptions.length; i++){
       b.require.apply(b, requireOptions[i]);
+    }
+
+    for(i = 0; i < transformOptions.length; i++){
+      b.transform.apply(b, transformOptions[i]);
     }
 
     return new RSVP.Promise(function (resolve, reject) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ function BrowserifyWriter(inputTree, options) {
   this.outputFile = options.outputFile || '/browserify.js';
   this.browserifyOptions = options.browserify || {};
   this.bundleOptions = options.bundle || {};
-  this.requireOptions = options.require || {};
+  this.requireOptions = options.require || [];
   this.transformOptions = options.transform || [];
   this.inputTree = inputTree;
 }


### PR DESCRIPTION
Notes:
- The implementation of this 'transform' option is identical in style to the recent 'require' option commit: https://github.com/gingerhendrix/broccoli-browserify/pull/4
- I also fixed a bug with the 'require' option, which should use an empty [] as default, not {}

Example transform config, using [coffeeify](https://github.com/jnordberg/coffeeify) and [aliasify](https://github.com/benbria/aliasify) transforms:

```
var appJs = browserify('app', {
    entries: [ './app.coffee' ],
    outputFile: 'app.js',
    browserify: {
        extensions: [ '.coffee' ],
    },
    transform: [
      [ 'coffeeify' ],
      [ { global: true }, 'aliasify' ]
    ]
});
```
