### PR TITLE
Add sourceMap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ tree = browserify(tree, options);
 * `entries` : (default `[]`) Array of files to be used as entry points
 * `outputFile`: (default `"./browserify.js"`) Output file
 * `browserify` : (default `{}`) Options passed to the [browserify constructor](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts)
-* `bundle`:  (default `{}`) Options passed to [browserify bundle method](https://github.com/substack/node-browserify#bbundleopts-cb)
 * `require`: (default []) An array of file, option pairs
 passed to [browserify require
 method](https://github.com/substack/node-browserify#brequirefile-opts)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,10 @@
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 var RSVP = require('rsvp');
 var mkdirp = require('mkdirp');
-var browserify = require('browserify')
+var browserify = require('browserify');
 var Writer = require('broccoli-writer');
 
 function BrowserifyWriter(inputTree, options) {
@@ -35,10 +37,11 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
     browserifyOptions.basedir = srcDir;
     var b = browserify(browserifyOptions);
 
-    for (var i = 0; i < entries.length; i++) {
+    var i;
+    for (i = 0; i < entries.length; i++) {
       b.add(entries[i]);
     }
-    for(var i = 0; i < requireOptions.length; i++){
+    for (i = 0; i < requireOptions.length; i++) {
       b.require.apply(b, requireOptions[i]);
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,6 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
   var entries = this.entries;
   var outputFile = this.outputFile;
   var browserifyOptions = this.browserifyOptions;
-  var bundleOptions = this.bundleOptions;
   var requireOptions = this.requireOptions;
 
   return readTree(this.inputTree).then(function (srcDir) {
@@ -44,7 +43,7 @@ BrowserifyWriter.prototype.write = function (readTree, destDir) {
     }
 
     return new RSVP.Promise(function (resolve, reject) {
-      b.bundle(bundleOptions, function (err, data) {
+      b.bundle(function (err, data) {
         if (err) {
           reject(err);
         } else {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "homepage": "https://github.com/gingerhendrix/broccoli-browserify",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
-    "rsvp": "^3.0.6",
-    "browserify": "^3.31.2",
-    "mkdirp": "^0.3.5"
+    "browserify": "^6.3.3",
+    "mkdirp": "^0.3.5",
+    "rsvp": "^3.0.6"
   },
   "devDependencies": {
     "jshint": "^2.4.4"


### PR DESCRIPTION
This updates Browserify version to latest v6.3.3 and allows for sourceMap generation via `{browserify: {debug: true}}` option.
